### PR TITLE
Remove console.log(); from lib file

### DIFF
--- a/doorman-lib.js
+++ b/doorman-lib.js
@@ -57,8 +57,6 @@ async function checkExistingOcean(msg) {
     let json = await fetch(OCEAN_URL+msg, requestOptions)
                          .then(response => response.json());
 
-    console.log(json);
-
     if (json.status=200) {
         if (json.answer.is_correct) {
             return "known fake";

--- a/doorman-lib.js
+++ b/doorman-lib.js
@@ -34,8 +34,6 @@ async function checkExistingSpacescience(id, strict=true) {
     let json = await fetch(SPACESCIENCE_URL+id, requestOptions)
                          .then(response => response.json());
 
-    console.log(json);
-
     for (let key in json) {
         if (json[key].hasOwnProperty("flag")) {
             if (json[key].flag == 1 && json[key].result === "LOSE") {


### PR DESCRIPTION
This statement was spamming the developer console with a lot of data very rapidly, that the users won't need, and that prevents coders from seeing other, more important log statements when using this function.